### PR TITLE
Fix for bad API requests to TC

### DIFF
--- a/app/tc2/tasks.py
+++ b/app/tc2/tasks.py
@@ -9,7 +9,9 @@ async def update_client_from_company(company: Company):
     """
     if cligency_id := company.tc2_cligency_id:
         client_data = TCClient(**await tc2_request(f'clients/{cligency_id}/')).dict()
-        extra_attrs = {f['machine_name']: f['value'] for f in client_data['extra_attrs']}
+        extra_attrs = {
+            f['machine_name']: f['value'].lower() if '-' not in f['value'] else '' for f in client_data['extra_attrs']
+        }
         extra_attrs.update(pipedrive_url=company.pd_org_url, pipedrive_id=company.pd_org_id)
         deal = await Deal.filter(company=company, status=Deal.STATUS_OPEN).first()
         if deal:

--- a/app/tc2/tasks.py
+++ b/app/tc2/tasks.py
@@ -10,7 +10,7 @@ async def update_client_from_company(company: Company):
     if cligency_id := company.tc2_cligency_id:
         client_data = TCClient(**await tc2_request(f'clients/{cligency_id}/')).dict()
         extra_attrs = {
-            f['machine_name']: f['value'].lower() if '-' not in f['value'] else '' for f in client_data['extra_attrs']
+            f['machine_name']: f['value'].lower() if '--' not in f['value'] else '' for f in client_data['extra_attrs']
         }
         extra_attrs.update(pipedrive_url=company.pd_org_url, pipedrive_id=company.pd_org_id)
         deal = await Deal.filter(company=company, status=Deal.STATUS_OPEN).first()

--- a/app/tc2/tasks.py
+++ b/app/tc2/tasks.py
@@ -10,7 +10,7 @@ async def update_client_from_company(company: Company):
     if cligency_id := company.tc2_cligency_id:
         client_data = TCClient(**await tc2_request(f'clients/{cligency_id}/')).dict()
         extra_attrs = {
-            f['machine_name']: f['value'].lower() if '--' not in f['value'] else '' for f in client_data['extra_attrs']
+            f['machine_name']: f['value'].lower() if not f['value'].startswith('---') else '' for f in client_data['extra_attrs']
         }
         extra_attrs.update(pipedrive_url=company.pd_org_url, pipedrive_id=company.pd_org_id)
         deal = await Deal.filter(company=company, status=Deal.STATUS_OPEN).first()

--- a/app/tc2/tasks.py
+++ b/app/tc2/tasks.py
@@ -10,7 +10,8 @@ async def update_client_from_company(company: Company):
     if cligency_id := company.tc2_cligency_id:
         client_data = TCClient(**await tc2_request(f'clients/{cligency_id}/')).dict()
         extra_attrs = {
-            f['machine_name']: f['value'].lower() if not f['value'].startswith('---') else '' for f in client_data['extra_attrs']
+            f['machine_name']: f['value'].lower() if not f['value'].startswith('---') else ''
+            for f in client_data['extra_attrs']
         }
         extra_attrs.update(pipedrive_url=company.pd_org_url, pipedrive_id=company.pd_org_id)
         deal = await Deal.filter(company=company, status=Deal.STATUS_OPEN).first()

--- a/tests/test_tc2.py
+++ b/tests/test_tc2.py
@@ -51,6 +51,8 @@ def _client_data():
         'status': 'live',
         'extra_attrs': [
             {'machine_name': 'pipedrive_url', 'value': 'https://example.pipedrive.com/organization/10'},
+            {'machine_name': 'how_did_you_hear_about_us_1', 'value': '----'},
+            {'machine_name': 'who_are_you_trying_to_reach', 'value': 'Support'},
         ],
         'user': {
             'email': 'mary@booth.com',
@@ -481,10 +483,12 @@ class TC2TasksTestCase(HermesTestCase):
                     },
                 ],
                 'extra_attrs': {
+                    'how_did_you_hear_about_us_1': '',
                     'pipedrive_url': f'{settings.pd_base_url}/organization/20/',
                     'pipedrive_id': 20,
                     'pipedrive_deal_stage': 'New',
                     'pipedrive_pipeline': 'payg',
+                    'who_are_you_trying_to_reach': 'support',
                 },
             }
         }


### PR DESCRIPTION
Close https://github.com/tutorcruncher/TutorCruncher2/issues/12823
Where we were entering '----', even though that's a value in the dropdown options, we need to enter an empty string via the api to set it to that value.
Then for the other values, we were passing things like 'Support' however we needed them to be lower case so 'support'

Those values all change to lowercase/empty strings because we call `list(zip(self.options_list, self.options_list))` on our dropdown options